### PR TITLE
work around libselinux.so issue

### DIFF
--- a/nocache.c
+++ b/nocache.c
@@ -186,33 +186,28 @@ FILE *fopen(const char *path, const char *mode)
 {
     int fd;
     FILE *fp;
-    fp=NULL;
-    if(!_original_fopen)
-    {      
-       _original_fopen = (FILE *(*)(const char *, const char *)) dlsym(RTLD_NEXT, "fopen");
-    }
-    if(_original_fopen)
-    {
+    fp = NULL;
+    if(!_original_fopen)         
+       _original_fopen = (FILE *(*)(const char *, const char *)) dlsym(RTLD_NEXT, "fopen");    
+    if(_original_fopen) {
        if((fp = _original_fopen(path, mode)) != NULL)
-          if((fd = fileno(fp)) != -1)
-               store_pageinfo(fd);
+           if((fd = fileno(fp)) != -1)
+            store_pageinfo(fd);
     }
     return fp;
 }
 
 int fclose(FILE *fp)
 {
-    if(!_original_fclose)
-    {      
-       _original_fclose = (int (*)(FILE *)) dlsym(RTLD_NEXT, "fclose");
-    }
-
-    if(_original_fclose)
-    {       
+    if(!_original_fclose)        
+        _original_fclose = (int (*)(FILE *)) dlsym(RTLD_NEXT, "fclose");  
+        
+    if(_original_fclose) {       
        free_unclaimed_pages(fileno(fp));
        return _original_fclose(fp);
     }
-    return 0;
+    errno = EFAULT;
+    return EOF;
 }
 
 static void store_pageinfo(int fd)


### PR DESCRIPTION
This issue came up in the real world because apparently
libselinux.so.1 does an fopen in a constructor function.
Big Thanks to Mike Shal (http://sourceware.org/ml/libc-help/2009-06/msg00000.html )
