### PR TITLE
Empty files provide the same output format and exit status as non empty ...

### DIFF
--- a/cachestats.c
+++ b/cachestats.c
@@ -57,8 +57,10 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     if(st.st_size == 0) {
-        fprintf(stderr, "%s: file size is 0!\n", argv[1]);
-        return EXIT_FAILURE;
+        printf("pages in cache: %d/%d (%.1f%%)  [filesize=%.1fK, "
+	       "pagesize=%dK]\n", 0, 0, 0.0,
+	       0.0, PAGESIZE / 1024);
+	return EXIT_SUCCESS;
     }
 
     pages = (st.st_size + PAGESIZE - 1) / PAGESIZE;


### PR DESCRIPTION
...files with cachestats => easier parsing

Hi Julius,

as the subject states this is to unify output format and behavior for scripts dealing with cachestats.

Cheers,
Reda
