### PR TITLE
[RFC] Add option to always flush all files content

### DIFF
--- a/README
+++ b/README
@@ -120,6 +120,19 @@ until it works, e.g.:
 
     $ env NOCACHE_NR_FADVISE=2 make test
 
+
+One could also consider that the fact pages are kept mean the kernel
+considers they are hot, and decide the overhead of allocating one byte
+per page for mincore and the actual mincore calls are not worth it when
+the kernel actually does keep some pages when it wants to.
+
+In this case you can either run `nocache` with `-f` or set the
+`NOCACHE_FLUSHALL` environment variable to 1, e.g.:
+
+    $ nocache -f cat ~/file.mp3
+    $ env NOCACHE_FLUSHALL=1 make test
+
+
 Alternate Approaches
 --------------------
 

--- a/nocache.in
+++ b/nocache.in
@@ -2,9 +2,10 @@
 
 export LD_PRELOAD="##libdir##/nocache.so $LD_PRELOAD"
 
-while getopts "n:D:" opt; do
+while getopts "n:D:f" opt; do
 case "$opt" in
     n) export NOCACHE_NR_FADVISE="$OPTARG" ;;
+    f) export NOCACHE_FLUSHALL=1 ;;
     D) exec {debugfd}>"$OPTARG"
        export NOCACHE_DEBUGFD="$debugfd"
        ;;


### PR DESCRIPTION
Add NOCACHE_FLUSHALL environment variable and matching -f switch
to the nocache wrapper.

The rationale behind this are multiple:
 - some applications might know the files being processed will never stay
in cache; in this case the overhead of flushing them is just not worth it
(we have some 24TB (sparse) file for which the mincore check is rather
costly)
 - given the kernel does have some heuristics to not respect the fadv
dontneed hint, one could consider it's just as simple to leave the logic
to it

-------

Hi! I've just found about this through #xfs@freenode, and it looks interesting; but needed something to skip the mincore for our use case.
Figured I could make it an option, and didn't see any issue/PR mentioning this so went ahead.
I've written [RFC] as it's mostly testing waters, I don't think I'd change much from this for a final version, but didn't want to spend time fiddling with details if people are against the idea.

Thanks!