### PR TITLE
Fix off by one issue with NOCACHE_MAX_FDS

### DIFF
--- a/README
+++ b/README
@@ -132,11 +132,12 @@ In this case you can either run `nocache` with `-f` or set the
     $ nocache -f cat ~/file.mp3
     $ env NOCACHE_FLUSHALL=1 make test
 
-By default `nocache` will only keep track of file descriptors less than 1
-million that are opened by your application, in order to bound its memory
+By default `nocache` will only keep track of file descriptors less than `2^20`
+that are opened by your application, in order to bound its memory
 consumption. If you want to change this threshold, you can supply the
 environment variable `NOCACHE_MAX_FDS` and set it to a higher (or lower) value.
-
+It should specify a value one greater than the maximum file descriptor that
+will be handled by `nocache`.
 
 Alternate Approaches
 --------------------

--- a/nocache.c
+++ b/nocache.c
@@ -409,7 +409,7 @@ static void store_pageinfo(int fd)
 {
     sigset_t mask, old_mask;
 
-    if(fd >= max_fds - 1)
+    if(fd >= max_fds)
         return;
 
     /* We might know something about this fd already, so assume we have missed

--- a/t/maxfd.t
+++ b/t/maxfd.t
@@ -4,11 +4,13 @@ NR=0
 
 . ./testlib.sh
 
-echo 1..3
+echo 1..5
 
 t "echo test > testfile.$$ && ../cachestats -q testfile.$$" "file is cached"
 t "while ../cachestats -q testfile.$$; do ../cachedel testfile.$$ && sleep 1; done" "file is not cached any more"
-t "env NOCACHE_MAX_FDS=1 LD_PRELOAD=../nocache.so cat testfile.$$ >/dev/null && ../cachestats -q testfile.$$" "file is in cache because it has an FD > 1"
+t "env NOCACHE_MAX_FDS=3 LD_PRELOAD=../nocache.so cat testfile.$$ >/dev/null && ../cachestats -q testfile.$$" "file is in cache because it has an FD >= 3"
+t "while ../cachestats -q testfile.$$; do ../cachedel testfile.$$ && sleep 1; done" "file is not cached any more"
+t "env NOCACHE_MAX_FDS=4 LD_PRELOAD=../nocache.so cat testfile.$$ >/dev/null && ! ../cachestats -q testfile.$$" "file is not in cache because it has an FD < 4"
 
 # clean up
 rm -f testfile.$$


### PR DESCRIPTION
Since NOCACHE_MAX_FDS should be an artificial cap for RLIMIT_NOFILE, it
should follow the same convention for its value - it should be one
greater than the maximum file descriptor that would be handled by
nocache. However, it currently is 2 greater than that file descriptor.

This commit resolves that. Also:
- tweaked mafd.t so it will correctly check for this problem
- touched the README file with small correction

Fixes #42 